### PR TITLE
T0wmadatasvc migration from rpm patch 2

### DIFF
--- a/docker/t0wmadatasvc/Dockerfile
+++ b/docker/t0wmadatasvc/Dockerfile
@@ -1,21 +1,30 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250716-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
-RUN dnf install -y git mariadb-connector-c mariadb-connector-c-devel gcc python3.12-devel 
+RUN sudo apt update -y && sudo apt install -y \
+  build-essential \
+  libmariadb-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
-ENV WDIR=/data
 ENV USER=_t0wmadatasvc
+ENV WDIR=/data
+ENV HDIR=/home/$USER
 ADD install.sh $WDIR/install.sh
 
 # add new user
 RUN useradd ${USER} && install -o ${USER} -d ${WDIR}
 # add user to sudoers file
 RUN echo "%$USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-# switch to user
-USER ${USER}
 
 # start the setup
 RUN mkdir -p $WDIR
+RUN mkdir -p $HDIR
+RUN sudo chown -R $USER:$USER $WDIR
+RUN sudo chown -R $USER:$USER $HDIR
+
+# switch to user
+USER ${USER}
 WORKDIR ${WDIR}
 
 # pass env variable to the build
@@ -28,10 +37,12 @@ RUN $WDIR/install.sh
 # run the service
 ADD run.sh $WDIR/run.sh
 ADD monitor.sh $WDIR/monitor.sh
+ADD config.py $WDIR/config.py
 
 USER $USER
 WORKDIR $WDIR
 
+ENV PATH="$PATH:${HDIR}/.local/bin/"
 ENV PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}/etc/secrets:/home/_t0wmadatasvc/.local/lib/python3.12/site-packages"
 
 CMD ["./run.sh"]

--- a/docker/t0wmadatasvc/Dockerfile
+++ b/docker/t0wmadatasvc/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:alma9-py3.12-20250529
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
-RUN yum install -y git
+RUN dnf install -y git mariadb-connector-c mariadb-connector-c-devel gcc python3-devel
+
 ENV WDIR=/data
 ENV USER=_t0wmadatasvc
 ADD install.sh $WDIR/install.sh

--- a/docker/t0wmadatasvc/Dockerfile
+++ b/docker/t0wmadatasvc/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:alma9-py3.12-20250529
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
-RUN dnf install -y git mariadb-connector-c mariadb-connector-c-devel gcc python3-devel
+RUN dnf install -y git mariadb-connector-c mariadb-connector-c-devel gcc python3.12-devel 
 
 ENV WDIR=/data
 ENV USER=_t0wmadatasvc

--- a/docker/t0wmadatasvc/Dockerfile
+++ b/docker/t0wmadatasvc/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:alma9-py3.12-20250529
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250716-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 RUN dnf install -y git mariadb-connector-c mariadb-connector-c-devel gcc python3.12-devel 

--- a/docker/t0wmadatasvc/Dockerfile
+++ b/docker/t0wmadatasvc/Dockerfile
@@ -31,5 +31,7 @@ ADD monitor.sh $WDIR/monitor.sh
 
 USER $USER
 WORKDIR $WDIR
-CMD ["./run.sh"]
 
+ENV PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}/etc/secrets:/home/_t0wmadatasvc/.local/lib/python3.12/site-packages"
+
+CMD ["./run.sh"]

--- a/docker/t0wmadatasvc/config.py
+++ b/docker/t0wmadatasvc/config.py
@@ -1,0 +1,46 @@
+import os, socket
+from WMCore.Configuration import Configuration
+
+class Config(Configuration):
+  """Default T0WmaDataSvc server configuration."""
+  def __init__(self, db = None, authkey = None, nthreads = 5, port = 8308):
+    """
+    :arg str db: Location of database configuration, "module.object". Defaults
+      to "t0auth.dbparam".
+    :arg str authkey: Location of wmcore security header authentication key.
+    :arg integer nthreads: Number of server threads to create.
+    :arg integer port: Server port."""
+
+    Configuration.__init__(self)
+    main = self.section_('main')
+    srv = main.section_('server')
+    srv.thread_pool = nthreads
+    main.application = 't0wmadatasvc'
+    main.port = port
+    main.index = 'data'
+
+    main.authz_defaults = { 'role': None, 'group': None, 'site': None }
+    sec = main.section_('tools').section_("cms_auth")
+    sec.key_file = authkey
+
+    app = self.section_('t0wmadatasvc')
+    app.admin = 'cms-service-cmsprod@cern.ch'
+    app.description = 'Access to the CMS Tier0 database'
+    app.title = 'CMS T0 WMAgent Data Service'
+
+    views = self.section_('views')
+    data = views.section_('data')
+    data.object = 'T0WmaDataSvc.Data.Data'
+    data.db = db or 't0auth.dbparam'
+    
+
+os.environ["NLS_LANG"] = ".AL32UTF8"
+
+THREADS = 10
+HOST = socket.gethostname().lower()
+KEY_FILE = "%s/auth/wmcore-auth/header-auth-key" % __file__.rsplit('/', 3)[0]
+config = Config(nthreads = THREADS, authkey = KEY_FILE)
+
+config.main.tools.cms_auth.policy = 'dangerously_insecure'
+config.main.server.environment = 'staging'
+config.main.server.socket_host = '127.0.0.1'

--- a/docker/t0wmadatasvc/install.sh
+++ b/docker/t0wmadatasvc/install.sh
@@ -5,5 +5,6 @@ TAG=2.1.1
 WMCORE_VERSION=2.4.1
 python -m pip install --upgrade pip
 python -m pip install wmcore==$WMCORE_VERSION
+python -m pip install future==1.0.0
 python -m pip install --no-cache-dir git+https://github.com/dmwm/t0wmadatasvc.git@$TAG
 

--- a/docker/t0wmadatasvc/install.sh
+++ b/docker/t0wmadatasvc/install.sh
@@ -3,5 +3,6 @@
 
 TAG=2.1.1
 pip install --upgrade pip
+pip install wmcore
 pip install --no-cache-dir git+https://github.com/dmwm/t0wmadatasvc.git@$TAG
 

--- a/docker/t0wmadatasvc/install.sh
+++ b/docker/t0wmadatasvc/install.sh
@@ -2,7 +2,8 @@
 #No longer using rpm for packaging t0wmadatasvc
 
 TAG=2.1.1
-pip install --upgrade pip
-pip install wmcore
-pip install --no-cache-dir git+https://github.com/dmwm/t0wmadatasvc.git@$TAG
+WMCORE_VERSION=2.4.1
+python -m pip install --upgrade pip
+python -m pip install wmcore==$WMCORE_VERSION
+python -m pip install --no-cache-dir git+https://github.com/dmwm/t0wmadatasvc.git@$TAG
 

--- a/docker/t0wmadatasvc/install.sh
+++ b/docker/t0wmadatasvc/install.sh
@@ -5,6 +5,6 @@ TAG=2.1.1
 WMCORE_VERSION=2.4.1
 python -m pip install --upgrade pip
 python -m pip install wmcore==$WMCORE_VERSION
-python -m pip install future==1.0.0
+python -m pip install backports.tarfile
 python -m pip install --no-cache-dir git+https://github.com/dmwm/t0wmadatasvc.git@$TAG
 

--- a/docker/t0wmadatasvc/run.sh
+++ b/docker/t0wmadatasvc/run.sh
@@ -102,7 +102,7 @@ for fname in $files; do
     fi
 done
 
-export PYTHONPATH=$PYTHONPATH:/etc/secrets:/home/_t0wmadatasvc/.local/lib/python3.12/site-packages/
+export PYTHONPATH="$PYTHONPATH:/etc/secrets:/home/_t0wmadatasvc/.local/lib/python3.12/site-packages/"
 
 cp /data/manage $CONFIGDIR/manage
 # start the service

--- a/docker/t0wmadatasvc/run.sh
+++ b/docker/t0wmadatasvc/run.sh
@@ -105,6 +105,7 @@ done
 export PYTHONPATH="$PYTHONPATH:/etc/secrets:/home/_t0wmadatasvc/.local/lib/python3.12/site-packages/"
 
 cp /data/manage $CONFIGDIR/manage
+cp /data/config.py $CONFIGDIR/config.py
 # start the service
 # $CONFIGDIR/manage start 'I did read documentation'
 

--- a/docker/t0wmadatasvc/run.sh
+++ b/docker/t0wmadatasvc/run.sh
@@ -104,9 +104,12 @@ done
 
 cp /data/manage $CONFIGDIR/manage
 # start the service
-$CONFIGDIR/manage start 'I did read documentation'
+# $CONFIGDIR/manage start 'I did read documentation'
 
 # run monitoring script
 if [ -f /data/monitor.sh ]; then
     /data/monitor.sh
 fi
+
+# hack to keep the container running
+tail -f /etc/hosts

--- a/docker/t0wmadatasvc/run.sh
+++ b/docker/t0wmadatasvc/run.sh
@@ -102,6 +102,8 @@ for fname in $files; do
     fi
 done
 
+export PYTHONPATH=$PYTHONPATH:/etc/secrets:/home/_t0wmadatasvc/.local/lib/python3.12/site-packages/
+
 cp /data/manage $CONFIGDIR/manage
 # start the service
 # $CONFIGDIR/manage start 'I did read documentation'

--- a/docker/t0wmadatasvc/run.sh
+++ b/docker/t0wmadatasvc/run.sh
@@ -1,28 +1,52 @@
 #!/bin/bash
+# script to start t0wmadatasvc
+
 srv=`echo $USER | sed -e "s,_,,g"`
+STATEDIR=/data/srv/state/$srv
+LOGDIR=/data/srv/logs/$srv
+AUTHDIR=/data/srv/current/auth/$srv
+CONFIGDIR=/data/srv/current/config/$srv
+CONFIGFILE=${CONFIGFILE:-config.py}
+CFGFILE=/etc/secrets/$CONFIGFILE
 
-# overwrite host PEM files in /data/srv area
+### Ensure the right ownership.
+sudo chown -R $USER.$USER /data
 
+### Populate WMCore conventional directory areas.
+mkdir -p $LOGDIR
+mkdir -p $STATEDIR
+mkdir -p $AUTHDIR
+mkdir -p $CONFIGDIR
+mkdir -p $AUTHDIR/../wmcore-auth
+
+# overwrite host PEM files in /data/srv area by the robot certificate
+# Note that the proxy file is not required and used
 if [ -f /etc/robots/robotkey.pem ]; then
-    sudo cp /etc/robots/robotkey.pem /data/srv/current/auth/$srv/dmwm-service-key.pem
-    sudo cp /etc/robots/robotcert.pem /data/srv/current/auth/$srv/dmwm-service-cert.pem
-    sudo chown $USER.$USER /data/srv/current/auth/$srv/dmwm-service-key.pem
-    sudo chown $USER.$USER /data/srv/current/auth/$srv/dmwm-service-cert.pem
+    sudo cp /etc/robots/robotkey.pem $AUTHDIR/dmwm-service-key.pem
+    sudo cp /etc/robots/robotcert.pem $AUTHDIR/dmwm-service-cert.pem
+    sudo chown $USER.$USER $AUTHDIR/dmwm-service-key.pem
+    sudo chown $USER.$USER $AUTHDIR/dmwm-service-cert.pem
+    sudo chmod 0400 $AUTHDIR/dmwm-service-key.pem
+fi
+
+if [ -e $AUTHDIR/dmwm-service-cert.pem ] && [ -e $AUTHDIR/dmwm-service-key.pem ]; then
+    export X509_USER_CERT=$AUTHDIR/dmwm-service-cert.pem
+    export X509_USER_KEY=$AUTHDIR/dmwm-service-key.pem
 fi
 
 # overwrite proxy if it is present in /etc/proxy
 if [ -f /etc/proxy/proxy ]; then
     export X509_USER_PROXY=/etc/proxy/proxy
-    mkdir -p /data/srv/state/$srv/proxy
-    if [ -f /data/srv/state/$srv/proxy/proxy.cert ]; then
-        rm /data/srv/state/$srv/proxy/proxy.cert
+    mkdir -p $STATEDIR/proxy
+    if [ -f $STATEDIR/proxy/proxy.cert ]; then
+        rm $STATEDIR/proxy/proxy.cert
     fi
-    ln -s /etc/proxy/proxy /data/srv/state/$srv/proxy/proxy.cert
-    mkdir -p /data/srv/current/auth/proxy
-    if [ -f /data/srv/current/auth/proxy/proxy ]; then
-        rm /data/srv/current/auth/proxy/proxy
+    ln -s /etc/proxy/proxy $STATEDIR/proxy/proxy.cert
+    mkdir -p $AUTHDIR/../proxy
+    if [ -f $AUTHDIR/../proxy/proxy ]; then
+        rm $AUTHDIR/../proxy/proxy
     fi
-    ln -s /etc/proxy/proxy /data/srv/current/auth/proxy/proxy
+    ln -s /etc/proxy/proxy $AUTHDIR/../proxy/proxy
 fi
 
 # overwrite header-auth key file with one from secrets
@@ -42,33 +66,47 @@ if [ -f /etc/hmac/hmac ]; then
     sudo chown $USER.$USER /data/srv/current/auth/$srv/header-auth-key
 fi
 
+# overwrite header-auth key file with one from secrets
+if [ -f /etc/hmac/hmac ]; then
+    if [ -f $AUTHDIR/../wmcore-auth/header-auth-key ]; then
+        sudo rm $AUTHDIR/../wmcore-auth/header-auth-key
+    fi
+    if [ -f $AUTHDIR/header-auth-key ]; then
+        sudo rm $AUTHDIR/header-auth-key
+    fi
+    sudo cp /etc/hmac/hmac $AUTHDIR/../wmcore-auth/header-auth-key
+    sudo chown $USER.$USER $AUTHDIR/../wmcore-auth/header-auth-key
+    sudo chmod 0600 $AUTHDIR/../wmcore-auth/header-auth-key
+
+    sudo cp /etc/hmac/hmac $AUTHDIR/header-auth-key
+    sudo chown $USER.$USER $AUTHDIR/header-auth-key
+    sudo chmod 0600 $AUTHDIR/header-auth-key
+fi
+
 # use service configuration files from /etc/secrets if they are present
-cdir=/data/srv/current/config/$srv
-files=`ls $cdir`
+files=`ls /etc/secrets`
 for fname in $files; do
     if [ -f /etc/secrets/$fname ]; then
-        if [ -f $cdir/$fname ]; then
-            rm $cdir/$fname
+        if [ -f $CONFIGDIR/$fname ]; then
+            rm $CONFIGDIR/$fname
         fi
-        sudo cp /etc/secrets/$fname $cdir/$fname
-        sudo chown $USER.$USER $cdir/$fname
+        sudo cp /etc/secrets/$fname $CONFIGDIR/$fname
+        sudo chown $USER.$USER $CONFIGDIR/$fname
     fi
 done
 files=`ls /etc/secrets`
 for fname in $files; do
-    if [ ! -f $cdir/$fname ]; then
-        sudo cp /etc/secrets/$fname /data/srv/current/auth/$srv/$fname
-        sudo chown $USER.$USER /data/srv/current/auth/$srv/$fname
+    if [ ! -f $CONFIGDIR/$fname ]; then
+        sudo cp /etc/secrets/$fname $AUTHDIR/$fname
+        sudo chown $USER.$USER $AUTHDIR/$fname
     fi
 done
 
+cp /data/manage $CONFIGDIR/manage
 # start the service
-/data/srv/current/config/$srv/manage start 'I did read documentation'
+$CONFIGDIR/manage start 'I did read documentation'
 
 # run monitoring script
 if [ -f /data/monitor.sh ]; then
     /data/monitor.sh
 fi
-
-# start cron daemon
-sudo /usr/sbin/crond -n


### PR DESCRIPTION
I've patched some issues. but the missing of wmc-httpd is not obvious to me, could be related to how we turn away from RPM install approach to pypi. I'll ask Dario for help.
- [x] [1] Crontab was no longer needed, we can safely removed it.
- [x] [2] misplaced _manage_ script.
- [x] [3] _/data/srv/current/{auth|state|config}_ were not populated properly.
- [x] [4] missing wmc-httpd, can't run manage start.
-----
- [ ] [5] [optional] changed /host/etc/grid-security -> /etc/grid-security in deployment